### PR TITLE
Fix wrap that occurred with off_t in win32

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -119,6 +119,7 @@ set(MAN_PAGES
   libssh2_publickey_remove_ex.3
   libssh2_publickey_shutdown.3
   libssh2_scp_recv.3
+  libssh2_scp_recv2.3
   libssh2_scp_send.3
   libssh2_scp_send64.3
   libssh2_scp_send_ex.3

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -89,6 +89,7 @@ dist_man_MANS = \
 	libssh2_publickey_remove_ex.3 \
 	libssh2_publickey_shutdown.3 \
 	libssh2_scp_recv.3 \
+	libssh2_scp_recv2.3 \
 	libssh2_scp_send.3 \
 	libssh2_scp_send64.3 \
 	libssh2_scp_send_ex.3 \

--- a/docs/libssh2_scp_recv2.3
+++ b/docs/libssh2_scp_recv2.3
@@ -1,16 +1,13 @@
-.TH libssh2_scp_recv 3 "1 Jun 2007" "libssh2 0.15" "libssh2 manual"
+.TH libssh2_scp_recv2 3 "29 Jun 2015" "libssh2 1.6.1" "libssh2 manual"
 .SH NAME
-libssh2_scp_recv - request a remote file via SCP
+libssh2_scp_recv2 - request a remote file via SCP
 .SH SYNOPSIS
 #include <libssh2.h>
 
 LIBSSH2_CHANNEL *
-libssh2_scp_recv(LIBSSH2_SESSION *session, const char *path, struct stat *sb);
+libssh2_scp_recv2(LIBSSH2_SESSION *session, const char *path, struct_stat *sb);
 
 .SH DESCRIPTION
-This function is \fBDEPRECATED\fP. Use \fIlibssh2_scp_recv2(3)\fP
-instead!
-
 \fIsession\fP - Session instance as returned by 
 .BR libssh2_session_init_ex(3)
 

--- a/example/scp.c
+++ b/example/scp.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
     const char *scppath="/tmp/TEST";
     libssh2_struct_stat fileinfo;
     int rc;
-    off_t got=0;
+    libssh2_struct_stat_size got = 0;
 
 #ifdef WIN32
     WSADATA wsadata;

--- a/example/scp.c
+++ b/example/scp.c
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
     const char *username="username";
     const char *password="password";
     const char *scppath="/tmp/TEST";
-    struct stat fileinfo;
+    libssh2_struct_stat fileinfo;
     int rc;
     off_t got=0;
 
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
     }
 
     /* Request a file via SCP */
-    channel = libssh2_scp_recv(session, scppath, &fileinfo);
+    channel = libssh2_scp_recv2(session, scppath, &fileinfo);
 
     if (!channel) {
         fprintf(stderr, "Unable to open a session: %d\n",

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -88,16 +88,16 @@ int main(int argc, char *argv[])
     const char *username="username";
     const char *password="password";
     const char *scppath="/tmp/TEST";
-    struct stat fileinfo;
+    libssh2_struct_stat fileinfo;
 #ifdef HAVE_GETTIMEOFDAY
     struct timeval start;
     struct timeval end;
     long time_ms;
 #endif
     int rc;
-    int total = 0;
     int spin = 0;
-    off_t got=0;
+    libssh2_struct_stat_size got = 0;
+    libssh2_struct_stat_size total = 0;
 
 #ifdef WIN32
     WSADATA wsadata;
@@ -207,9 +207,9 @@ int main(int argc, char *argv[])
 #endif
 
     /* Request a file via SCP */
-    fprintf(stderr, "libssh2_scp_recv()!\n");
+    fprintf(stderr, "libssh2_scp_recv2()!\n");
     do {
-        channel = libssh2_scp_recv(session, scppath, &fileinfo);
+        channel = libssh2_scp_recv2(session, scppath, &fileinfo);
 
         if (!channel) {
             if(libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
@@ -262,10 +262,10 @@ int main(int argc, char *argv[])
     gettimeofday(&end, NULL);
 
     time_ms = tvdiff(end, start);
-    fprintf(stderr, "Got %d bytes in %ld ms = %.1f bytes/sec spin: %d\n", total,
-           time_ms, total/(time_ms/1000.0), spin );
+    fprintf(stderr, "Got " LIBSSH2_STRUCT_STAT_SIZE_FORMAT " bytes in %ld ms = %.1f bytes/sec spin: %d\n", total,
+           time_ms, total/(time_ms/1000.0), spin);
 #else
-    fprintf(stderr, "Got %d bytes spin: %d\n", total, spin);
+    fprintf(stderr, "Got " LIBSSH2_STRUCT_STAT_SIZE_FORMAT " bytes spin: %d\n", total, spin);
 #endif
 
     libssh2_channel_free(channel);

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -243,7 +243,7 @@ int main(int argc, char *argv[])
 
     /* Other channel types are supported via:
      * libssh2_scp_send()
-     * libssh2_scp_recv()
+     * libssh2_scp_recv2()
      * libssh2_channel_direct_tcpip()
      */
 

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
 
     /* Other channel types are supported via:
      * libssh2_scp_send()
-     * libssh2_scp_recv()
+     * libssh2_scp_recv2()
      * libssh2_channel_direct_tcpip()
      */
 

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -181,16 +181,9 @@ typedef int libssh2_socket_t;
 #  include <io.h>
 #  include <sys/types.h>
 #  include <sys/stat.h>
-#  undef  lseek
-#  define lseek(fdes,offset,whence)          _lseeki64(fdes, offset, whence)
-#  undef  fstat
-#  define fstat(fdes,stp)                    _fstati64(fdes, stp)
-#  undef  stat
-#  define stat(fname,stp)                    _stati64(fname, stp)
 #  define libssh2_struct_stat                struct _stati64
 #  define libssh2_struct_stat_size           __int64
 #  define LIBSSH2_STRUCT_STAT_SIZE_FORMAT    "%I64d"
-#  define LSEEK_ERROR                        (__int64)-1
 #endif
 
 /*
@@ -198,29 +191,20 @@ typedef int libssh2_socket_t;
  */
 
 #ifdef USE_WIN32_SMALL_FILES
-#  include <io.h>
 #  include <sys/types.h>
 #  include <sys/stat.h>
 #  ifndef _WIN32_WCE
 #    undef  lseek
-#    define lseek(fdes,offset,whence)          _lseek(fdes, (long)offset, whence)
-#    define fstat(fdes,stp)                    _fstat(fdes, stp)
-#    define stat(fname,stp)                    _stat(fname, stp)
 #    define libssh2_struct_stat                struct _stat
 #    define libssh2_struct_stat_size           off_t
 #    define LIBSSH2_STRUCT_STAT_SIZE_FORMAT    "%d"
 #  endif
-#  define LSEEK_ERROR                          (long)-1
 #endif
 
 #ifndef libssh2_struct_stat
 #  define libssh2_struct_stat                  struct stat
 #  define libssh2_struct_stat_size             off_t
 #  define LIBSSH2_STRUCT_STAT_SIZE_FORMAT      "%zd"
-#endif
-
-#ifndef LSEEK_ERROR
-#  define LSEEK_ERROR (off_t)-1
 #endif
 
 /* Part of every banner, user specified or not */

--- a/nw/GNUmakefile
+++ b/nw/GNUmakefile
@@ -545,6 +545,7 @@ endif
 	@echo $(DL)  libssh2_knownhost_readfile,$(DL) >> $@
 	@echo $(DL)  libssh2_knownhost_writefile,$(DL) >> $@
 	@echo $(DL)  libssh2_scp_recv,$(DL) >> $@
+	@echo $(DL)  libssh2_scp_recv2,$(DL) >> $@
 	@echo $(DL)  libssh2_scp_send64,$(DL) >> $@
 	@echo $(DL)  libssh2_scp_send_ex,$(DL) >> $@
 	@echo $(DL)  libssh2_session_abstract,$(DL) >> $@

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ include(CheckSymbolExists)
 include(CheckFunctionExistsMayNeedLibrary)
 include(CheckIncludeFiles)
 include(CheckTypeSize)
+include(CheckSymbolExists)
 include(CheckNonblockingSocketSupport)
 include(SocketLibraries)
 
@@ -280,6 +281,10 @@ if(HAVE_STDLIB_H)
   check_symbol_exists(strtoll stdlib.h HAVE_STRTOLL)
 else()
   check_function_exists(strtoll HAVE_STRTOLL)
+endif()
+if (NOT HAVE_STRTOLL)
+  # Try _strtoi64 if strtoll isn't available
+  check_symbol_exists(_strtoi64 stdlib.h HAVE_STRTOI64)
 endif()
 check_symbol_exists(snprintf stdio.h HAVE_SNPRINTF)
 

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -64,6 +64,7 @@
 #cmakedefine HAVE_SELECT
 #cmakedefine HAVE_SOCKET
 #cmakedefine HAVE_STRTOLL
+#cmakedefine HAVE_STRTOI64
 #cmakedefine HAVE_SNPRINTF
 
 /* OpenSSL functions */
@@ -76,6 +77,9 @@
 #cmakedefine HAVE_IOCTLSOCKET_CASE
 #cmakedefine HAVE_SO_NONBLOCK
 #cmakedefine HAVE_DISABLED_NONBLOCKING
+
+/* Define to 1 if you are building a Windows target with large file support. */
+#cmakedefine USE_WIN32_LARGE_FILES 1
 
 /* snprintf not in Visual Studio CRT and _snprintf dangerously incompatible.
    We provide a safe wrapper if snprintf not found */

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -78,9 +78,6 @@
 #cmakedefine HAVE_SO_NONBLOCK
 #cmakedefine HAVE_DISABLED_NONBLOCKING
 
-/* Define to 1 if you are building a Windows target with large file support. */
-#cmakedefine USE_WIN32_LARGE_FILES 1
-
 /* snprintf not in Visual Studio CRT and _snprintf dangerously incompatible.
    We provide a safe wrapper if snprintf not found */
 #ifndef HAVE_SNPRINTF

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -779,7 +779,7 @@ struct _LIBSSH2_SESSION
     int sftpInit_sent; /* number of bytes from the buffer that have been
                           sent */
 
-    /* State variables used in libssh2_scp_recv() */
+    /* State variables used in libssh2_scp_recv() / libssh_scp_recv2() */
     libssh2_nonblocking_states scpRecv_state;
     unsigned char *scpRecv_command;
     size_t scpRecv_command_len;
@@ -790,6 +790,9 @@ struct _LIBSSH2_SESSION
     /* we have the type and we can parse such numbers */
     long long scpRecv_size;
 #define scpsize_strtol strtoll
+#elif defined(HAVE_STRTOI64)
+    __int64 scpRecv_size;
+#define scpsize_strtol _strtoi64
 #else
     long scpRecv_size;
 #define scpsize_strtol strtol

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -918,6 +918,38 @@ struct _LIBSSH2_COMP_METHOD
     int (*dtor) (LIBSSH2_SESSION * session, int compress, void **abstract);
 };
 
+/*
+ * Large file (>2Gb) support using WIN32 functions.
+ */
+
+#ifdef USE_WIN32_LARGE_FILES
+#  include <io.h>
+#  include <sys/types.h>
+#  include <sys/stat.h>
+#  undef  lseek
+#  define lseek(fdes,offset,whence)          _lseeki64(fdes, offset, whence)
+#  undef  fstat
+#  define fstat(fdes,stp)                    _fstati64(fdes, stp)
+#  undef  stat
+#  define stat(fname,stp)                    _stati64(fname, stp)
+#endif
+
+/*
+ * Small file (<2Gb) support using WIN32 functions.
+ */
+
+#ifdef USE_WIN32_SMALL_FILES
+#  include <io.h>
+#  include <sys/types.h>
+#  include <sys/stat.h>
+#  ifndef _WIN32_WCE
+#    undef  lseek
+#    define lseek(fdes,offset,whence)          _lseek(fdes, (long)offset, whence)
+#    define fstat(fdes,stp)                    _fstat(fdes, stp)
+#    define stat(fname,stp)                    _stat(fname, stp)
+#  endif
+#endif
+
 #ifdef LIBSSH2DEBUG
 void _libssh2_debug(LIBSSH2_SESSION * session, int context, const char *format,
                     ...);


### PR DESCRIPTION
Hi, here it is, down to the one line that needs to be changed to fix the example and get a successful test with a large file on 32 bit windows.
